### PR TITLE
Ported hash_to_xml function hash2xml

### DIFF
--- a/lib/puppet/functions/hash2xml.rb
+++ b/lib/puppet/functions/hash2xml.rb
@@ -43,6 +43,10 @@ Puppet::Functions.create_function(:hash2xml) do
         xml += kv_to_xml(key, nil, level, false, true)
       when FalseClass
         xml += kv_to_xml(key, nil, level, true, false)
+      when Array
+        value.each do |v|
+          xml += hash_to_xml({ key => v }, level, @character, @num)
+        end
       else
         raise ArgumentError, "'hash2xml': unable to convert a value with type %s" % [value.class.name]
       end

--- a/lib/puppet/functions/hash2xml.rb
+++ b/lib/puppet/functions/hash2xml.rb
@@ -1,0 +1,52 @@
+# Original source: https://github.com/WhatsARanjit/puppet-hash_to_xml
+Puppet::Functions.create_function(:hash2xml) do
+  dispatch :hash2xml do
+    param 'Hash', :input
+    optional_param 'Hash', :options
+    return_type 'String'
+  end
+
+  def hash2xml(input, options = {})
+    settings = {
+      'level' => 0,
+      'indent_size' => 2,
+      'indent_char' => "\s",
+    }
+    settings.merge!(options)
+    hash_to_xml(input, settings['level'], settings['indent_char'], settings['indent_size'])
+  end
+
+  def calc_indent(level)
+    @character * @num * level
+  end
+
+  def kv_to_xml(k, v = nil, level = 0, open = true, close = true)
+    output = ''
+    output += calc_indent(level)
+    output +="<#{k}>" if open
+    output += v if (open and close)
+    output += "</#{k.split(/\s/, 2)[0]}>" if close
+    output += "\n"
+  end
+
+  def hash_to_xml(input, level = 0, character = "\s", num = 2)
+    @character             = character
+    @num                   = num
+    xml                    = ''
+    input.each do |key, value|
+      case value
+      when String
+        xml += kv_to_xml(key, value, level)
+      when Hash
+        xml += kv_to_xml(key, nil, level, true, false)
+        xml += hash_to_xml(value, level+1, @character, @num)
+        xml += kv_to_xml(key, nil, level, false, true)
+      when FalseClass
+        xml += kv_to_xml(key, nil, level, true, false)
+      else
+        fail('Error')
+      end
+    end
+    return xml
+  end
+end

--- a/lib/puppet/functions/hash2xml.rb
+++ b/lib/puppet/functions/hash2xml.rb
@@ -23,10 +23,10 @@ Puppet::Functions.create_function(:hash2xml) do
   def kv_to_xml(k, v = nil, level = 0, open = true, close = true)
     output = ''
     output += calc_indent(level)
-    output +="<#{k}>" if open
-    output += v if (open and close)
-    output += "</#{k.split(/\s/, 2)[0]}>" if close
-    output += "\n"
+    output += "<#{k}>" if open
+    output += v if open && close
+    output += "</#{k.split(%r{\s}, 2)[0]}>" if close
+    output + "\n"
   end
 
   def hash_to_xml(input, level = 0, character = "\s", num = 2)
@@ -39,14 +39,14 @@ Puppet::Functions.create_function(:hash2xml) do
         xml += kv_to_xml(key, value, level)
       when Hash
         xml += kv_to_xml(key, nil, level, true, false)
-        xml += hash_to_xml(value, level+1, @character, @num)
+        xml += hash_to_xml(value, level + 1, @character, @num)
         xml += kv_to_xml(key, nil, level, false, true)
       when FalseClass
         xml += kv_to_xml(key, nil, level, true, false)
       else
-        fail('Error')
+        raise ArgumentError, "'hash2xml': unable to convert a value with type %s" % [value.class.name]
       end
     end
-    return xml
+    xml
   end
 end

--- a/lib/puppet/functions/hash2xml.rb
+++ b/lib/puppet/functions/hash2xml.rb
@@ -1,5 +1,63 @@
+# frozen_string_literal: true
+#
 # Original source: https://github.com/WhatsARanjit/puppet-hash_to_xml
+
+# @summary Converts a hash to a xml snippet.
+#
+# **Options**
+#
+# These options can be used to adjust output.
+#
+# * **`indent_size`** (`Integer`): How many times to repeat indent_char in each additional indentation level. Defaults to `2`.
+# * **`indent_char`** (`String`): Which character to use when indenting. Defaults to ` ` (space).
+# * **`level`** (`Integer`): Indentation level to start at.
+#
 Puppet::Functions.create_function(:hash2xml) do
+  # Converts a hash to a valid xml snippet
+  #
+  # @example Create a xml file
+  #   hash2xml({
+  #     'collection version="1"' => {
+  #       'name' => 'Puppetlabs',
+  #       'properties' => {
+  #         'foo' => 'bar',
+  #         'bar' => 'foo',
+  #       },
+  #       'books' => {
+  #         'book' => [
+  #           {
+  #             "name" => "The Tools for Learning Puppet: Command Line, Vim &amp; Git",
+  #             "url"  => "https://puppet.com/resources/ebook/tools-for-learning-puppet",
+  #           },
+  #           {
+  #             "name" => "DevOps Mythbusting",
+  #             "url"  => "https://puppet.com/resources/ebook/devops-mythbusting",
+  #           },
+  #         ],
+  #       },
+  #     },
+  #   })
+  #   # =>
+  #   # <collection version="1">
+  #   #   <name>Puppetlabs</name>
+  #   #   <properties>
+  #   #     <foo>bar</foo>
+  #   #     <bar>foo</bar>
+  #   #   </properties>
+  #   #   <books>
+  #   #     <book>
+  #   #       <name>The Tools for Learning Puppet: Command Line, Vim &amp; Git</name>
+  #   #       <url>https://puppet.com/resources/ebook/tools-for-learning-puppet</url>
+  #   #     </book>
+  #   #     <book>
+  #   #       <name>DevOps Mythbusting</name>
+  #   #       <url>https://puppet.com/resources/ebook/devops-mythbusting</url>
+  #   #     </book>
+  #   #   </books>
+  #   # </collection>
+  #
+  # @param input A hash to be formatted as xml.
+  # @param options A hash of options to control the output.
   dispatch :hash2xml do
     param 'Hash', :input
     optional_param 'Hash', :options

--- a/spec/functions/hash2xml_spec.rb
+++ b/spec/functions/hash2xml_spec.rb
@@ -22,6 +22,10 @@ describe 'hash2xml' do
   it { is_expected.to run.with_params({}, {}, {}).and_raise_error(ArgumentError, %r{'hash2xml' expects between 1 and 2 arguments, got 3}) }
   it { is_expected.to run.with_params('some string').and_raise_error(ArgumentError, %r{'hash2xml' parameter 'input'}) }
 
+  it 'fails with unsupported value types' do
+    is_expected.to run.with_params('foo' => true).and_raise_error(ArgumentError, %r{'hash2xml': unable to convert a value with type TrueClass})
+  end
+
   context 'default settings' do
     it 'outputs xml' do
       is_expected.to run.with_params(example_input).and_return(<<-EOS

--- a/spec/functions/hash2xml_spec.rb
+++ b/spec/functions/hash2xml_spec.rb
@@ -1,0 +1,120 @@
+require 'spec_helper'
+
+describe 'hash2xml' do
+  let(:example_input) do
+    {
+      'sheet' => {
+        'head' => {
+          'title' => 'Test Xml',
+        },
+        'entries' => {
+          'entry' => {
+            'name' => 'foo',
+            'tag attribute="foobar"' => 'bar',
+          },
+        },
+      },
+    }
+  end
+
+  it { is_expected.not_to eq(nil) }
+  it { is_expected.to run.with_params.and_raise_error(ArgumentError, %r{'hash2xml' expects between 1 and 2 arguments, got none}) }
+  it { is_expected.to run.with_params({}, {}, {}).and_raise_error(ArgumentError, %r{'hash2xml' expects between 1 and 2 arguments, got 3}) }
+  it { is_expected.to run.with_params('some string').and_raise_error(ArgumentError, %r{'hash2xml' parameter 'input'}) }
+
+  context 'default settings' do
+    it 'outputs xml' do
+      is_expected.to run.with_params(example_input).and_return(<<-EOS
+<sheet>
+  <head>
+    <title>Test Xml</title>
+  </head>
+  <entries>
+    <entry>
+      <name>foo</name>
+      <tag attribute="foobar">bar</tag>
+    </entry>
+  </entries>
+</sheet>
+      EOS
+                                                              )
+    end
+  end
+
+  context 'custom settings' do
+    let(:example_input) do
+      {
+        'entry' => 'foo',
+        'nest' => {
+          'entry' => 'bar',
+          'nest' => {
+            'entry' => 'foobar',
+          },
+        },
+      }
+    end
+
+    let(:settings) do
+      {
+        'indent_size' => 2,
+        'indent_char' => "\s",
+      }
+    end
+
+    context 'level' do
+      let(:settings) { super().merge('level' => 2) }
+
+      it 'starts at correct level' do
+        is_expected.to run.with_params(example_input, settings).and_return(
+          <<-EOS
+    <entry>foo</entry>
+    <nest>
+      <entry>bar</entry>
+      <nest>
+        <entry>foobar</entry>
+      </nest>
+    </nest>
+          EOS
+        )
+      end
+    end
+
+    context 'indent' do
+      describe 'custom indent size' do
+        let(:settings) { super().merge('indent_size' => 4) }
+
+        it 'uses correct indent size' do
+          is_expected.to run.with_params(example_input, settings).and_return(
+            <<-EOS
+<entry>foo</entry>
+<nest>
+    <entry>bar</entry>
+    <nest>
+        <entry>foobar</entry>
+    </nest>
+</nest>
+            EOS
+          )
+        end
+      end
+
+      describe 'custom indent character' do
+        let(:settings) { super().merge('indent_char' => "\t") }
+
+        it 'uses correct indent character' do
+          is_expected.to run.with_params(example_input, settings).and_return(
+            <<-EOS
+<entry>foo</entry>
+<nest>
+\t\t<entry>bar</entry>
+\t\t<nest>
+\t\t\t\t<entry>foobar</entry>
+\t\t</nest>
+</nest>
+            EOS
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/functions/hash2xml_spec.rb
+++ b/spec/functions/hash2xml_spec.rb
@@ -8,10 +8,20 @@ describe 'hash2xml' do
           'title' => 'Test Xml',
         },
         'entries' => {
-          'entry' => {
-            'name' => 'foo',
-            'tag attribute="foobar"' => 'bar',
-          },
+          'entry' => [
+            {
+              'name' => 'foo',
+              'tag attribute="foobar"' => 'bar',
+            },
+            {
+              'name' => 'bar',
+            },
+            {
+              'more' => {
+                'count' => ['one', 'two', 'three'],
+              },
+            },
+          ],
         },
       },
     }
@@ -37,6 +47,16 @@ describe 'hash2xml' do
     <entry>
       <name>foo</name>
       <tag attribute="foobar">bar</tag>
+    </entry>
+    <entry>
+      <name>bar</name>
+    </entry>
+    <entry>
+      <more>
+        <count>one</count>
+        <count>two</count>
+        <count>three</count>
+      </more>
     </entry>
   </entries>
 </sheet>


### PR DESCRIPTION
Usage (options) is a bit different to make it more in style with other hash2* functions.

- [x] Docs
- [x] Array support => repeat tags