### PR TITLE
Document true/false useage in hash2xml

### DIFF
--- a/lib/puppet/functions/hash2xml.rb
+++ b/lib/puppet/functions/hash2xml.rb
@@ -15,10 +15,15 @@
 Puppet::Functions.create_function(:hash2xml) do
   # Converts a hash to a valid xml snippet
   #
+  # When a keypair value is `false`, the tag will not be closed.
+  # When a keypair value is `true`, the short `<tag/>` will be used.
+  #
   # @example Create a xml file
   #   hash2xml({
+  #     '?xml version="1.0" encoding="UTF-8"?' => false,
   #     'collection version="1"' => {
   #       'name' => 'Puppetlabs',
+  #       'no_text attribute="foobar"' => false,
   #       'properties' => {
   #         'foo' => 'bar',
   #         'bar' => 'foo',
@@ -38,6 +43,7 @@ Puppet::Functions.create_function(:hash2xml) do
   #     },
   #   })
   #   # =>
+  #   # <?xml version="1.0" encoding="UTF-8"?>
   #   # <collection version="1">
   #   #   <name>Puppetlabs</name>
   #   #   <properties>
@@ -101,6 +107,8 @@ Puppet::Functions.create_function(:hash2xml) do
         xml += kv_to_xml(key, nil, level, false, true)
       when FalseClass
         xml += kv_to_xml(key, nil, level, true, false)
+      when TrueClass
+        xml += kv_to_xml("#{key}/", nil, level, true, false)
       when Array
         value.each do |v|
           xml += hash_to_xml({ key => v }, level, @character, @num)

--- a/spec/functions/hash2xml_spec.rb
+++ b/spec/functions/hash2xml_spec.rb
@@ -3,10 +3,12 @@ require 'spec_helper'
 describe 'hash2xml' do
   let(:example_input) do
     {
+      '?xml version="1.0" encoding="UTF-8"?' => false,
       'sheet' => {
         'head' => {
           'title' => 'Test Xml',
         },
+        'meta tag="value"' => true,
         'entries' => {
           'entry' => [
             {
@@ -33,16 +35,18 @@ describe 'hash2xml' do
   it { is_expected.to run.with_params('some string').and_raise_error(ArgumentError, %r{'hash2xml' parameter 'input'}) }
 
   it 'fails with unsupported value types' do
-    is_expected.to run.with_params('foo' => true).and_raise_error(ArgumentError, %r{'hash2xml': unable to convert a value with type TrueClass})
+    is_expected.to run.with_params('foo' => 1.1).and_raise_error(ArgumentError, %r{'hash2xml': unable to convert a value with type Float})
   end
 
   context 'default settings' do
     it 'outputs xml' do
       is_expected.to run.with_params(example_input).and_return(<<-EOS
+<?xml version="1.0" encoding="UTF-8"?>
 <sheet>
   <head>
     <title>Test Xml</title>
   </head>
+  <meta tag="value"/>
   <entries>
     <entry>
       <name>foo</name>


### PR DESCRIPTION
Added support for <short/> tags using `true`.